### PR TITLE
fix:  change name Informatie Vlaanderen to Digitaal Vlaanderen

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2019 agentschap Informatie Vlaanderen
+Copyright (c) 2018-2019 agentschap Digitaal Vlaanderen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ public IServiceProvider ConfigureServices(IServiceCollection services)
               Description = GetApiLeadingText(description),
               Contact = new Contact
               {
-                  Name = "agentschap Informatie Vlaanderen",
-                  Email = "informatie.vlaanderen@vlaanderen.be",
+                  Name = "agentschap Digitaal Vlaanderen",
+                  Email = "digitaal.vlaanderen@vlaanderen.be",
                   Url = "https://vlaanderen.be/informatie-vlaanderen"
               }
           },

--- a/src/Be.Vlaanderen.Basisregisters.AspNetCore.Swagger.ReDoc/paket.template
+++ b/src/Be.Vlaanderen.Basisregisters.AspNetCore.Swagger.ReDoc/paket.template
@@ -5,8 +5,8 @@ id Be.Vlaanderen.Basisregisters.AspNetCore.Swagger.ReDoc
 title Be.Vlaanderen.Basisregisters.AspNetCore.Swagger.ReDoc
 
 authors Basisregisters Vlaanderen
-owners agentschap Informatie Vlaanderen <https://vlaanderen.be/informatie-vlaanderen>
-copyright Copyright (c) agentschap Informatie Vlaanderen
+owners agentschap Digitaal Vlaanderen <https://vlaanderen.be/informatie-vlaanderen>
+copyright Copyright (c) agentschap Digitaal Vlaanderen
 requireLicenseAcceptance false
 projectUrl https://github.com/Informatievlaanderen/swagger
 iconUrl https://raw.githubusercontent.com/Informatievlaanderen/build-pipeline/master/logo.png

--- a/src/Be.Vlaanderen.Basisregisters.AspNetCore.Swagger.ReDoc/www/api-documentation.html
+++ b/src/Be.Vlaanderen.Basisregisters.AspNetCore.Swagger.ReDoc/www/api-documentation.html
@@ -70,7 +70,7 @@
           <span>uitgegeven door</span>
           <span itemprop="publisher" itemscope="" itemtype="http://schema.org/Organization">
             <a itemprop="url" href="https://www.vlaanderen.be/nl/contact/adressengids/diensten-van-de-vlaamse-overheid/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-informatie-vlaanderen" target="_self">
-              <span itemprop="name">Informatie Vlaanderen</span></a><span id="vbrVersion">, versie %(FooterVersion)</span>
+              <span itemprop="name">Digitaal Vlaanderen</span></a><span id="vbrVersion">, versie %(FooterVersion)</span>
           </span>
         </div>
       </div>

--- a/src/Be.Vlaanderen.Basisregisters.AspNetCore.Swagger/paket.template
+++ b/src/Be.Vlaanderen.Basisregisters.AspNetCore.Swagger/paket.template
@@ -5,8 +5,8 @@ id Be.Vlaanderen.Basisregisters.AspNetCore.Swagger
 title Be.Vlaanderen.Basisregisters.AspNetCore.Swagger
 
 authors Basisregisters Vlaanderen
-owners agentschap Informatie Vlaanderen <https://vlaanderen.be/informatie-vlaanderen>
-copyright Copyright (c) agentschap Informatie Vlaanderen
+owners agentschap Digitaal Vlaanderen <https://vlaanderen.be/informatie-vlaanderen>
+copyright Copyright (c) agentschap Digitaal Vlaanderen
 requireLicenseAcceptance false
 projectUrl https://github.com/Informatievlaanderen/swagger
 iconUrl https://raw.githubusercontent.com/Informatievlaanderen/build-pipeline/master/logo.png

--- a/test/Dummy.Api/Properties/AssemblyInfo.cs
+++ b/test/Dummy.Api/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Dummy API")]
 [assembly: AssemblyVersion("2.1.8.3")]
 [assembly: AssemblyFileVersion("2.1.8.3")]
-[assembly: AssemblyCopyright("Copyright (c) agentschap Informatie Vlaanderen")]
-[assembly: AssemblyCompany("agentschap Informatie Vlaanderen")]
+[assembly: AssemblyCopyright("Copyright (c) agentschap Digitaal Vlaanderen")]
+[assembly: AssemblyCompany("agentschap Digitaal Vlaanderen")]
 
 [assembly: Guid("148c9c45-ac1d-411c-a13f-908a9c7009e1")]

--- a/test/Dummy.Api/Startup.cs
+++ b/test/Dummy.Api/Startup.cs
@@ -65,8 +65,8 @@ namespace Dummy.Api
                         Description = GetApiLeadingText(description),
                         Contact = new OpenApiContact
                         {
-                            Name = "agentschap Informatie Vlaanderen",
-                            Email = "informatie.vlaanderen@vlaanderen.be",
+                            Name = "agentschap Digitaal Vlaanderen",
+                            Email = "digitaal.vlaanderen@vlaanderen.be",
                             Url = new Uri("https://vlaanderen.be/informatie-vlaanderen")
                         },
                         License = new OpenApiLicense

--- a/test/Dummy.Api/XmlController.cs
+++ b/test/Dummy.Api/XmlController.cs
@@ -62,8 +62,8 @@ namespace Dummy.Api
     <rights>Gratis hergebruik volgens https://overheid.vlaanderen.be/sites/default/files/documenten/ict-egov/licenties/hergebruik/modellicentie_gratis_hergebruik_v1_0.html</rights>
     <updated>2020-09-18T06:25:34Z</updated>
     <author>
-        <name>agentschap Informatie Vlaanderen</name>
-        <email>informatie.vlaanderen@vlaanderen.be</email>
+        <name>agentschap Digitaal Vlaanderen</name>
+        <email>digitaal.vlaanderen@vlaanderen.be</email>
     </author>
     <link href=""https://api.basisregisters.dev-vlaanderen.be/v1/feeds/gebouwen"" rel=""self"" />
     <link href=""https://api.basisregisters.dev-vlaanderen.be/v1/feeds/gebouwen.atom"" rel=""alternate"" type=""application/atom+xml"" />


### PR DESCRIPTION
@ArneD 